### PR TITLE
Autoprefixer issue

### DIFF
--- a/app/templates/Makefile
+++ b/app/templates/Makefile
@@ -19,8 +19,9 @@ build/css:
 	mkdir -p $@
 
 css: build/css
-	$(NPM_BIN)/node-sass client/scss --output-style compressed -o build/css \
-		| $(NPM_BIN)/autoprefixer -b "last 2 versions"
+	$(NPM_BIN)/node-sass client/scss --output-style compressed -o build/css && postcss --use autoprefixer --autoprefixer.browsers "last 2 versions" -d build/css/ build/css/*.css
+
+
 
 #
 # JAVASCRIPT

--- a/app/templates/Makefile
+++ b/app/templates/Makefile
@@ -19,7 +19,8 @@ build/css:
 	mkdir -p $@
 
 css: build/css
-	$(NPM_BIN)/node-sass client/scss --output-style compressed -o build/css && postcss --use autoprefixer --autoprefixer.browsers "last 2 versions" -d build/css/ build/css/*.css
+	$(NPM_BIN)/node-sass client/scss --output-style compressed -o build/css \
+	&& postcss --use autoprefixer --autoprefixer.browsers "last 2 versions" -d build/css/ build/css/*.css
 
 
 

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -21,7 +21,7 @@
     "transform": [["babelify", { "blacklist": ["regenerator"] }]]
   },
   "dependencies": {
-    "autoprefixer": "^5.1.0",
+    "postcss-cli": "^2.1.0",
     "browserify": "^11.0.1",
     "loglevel": "^1.2.0",
     "react": "~0.13.3",

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -21,6 +21,7 @@
     "transform": [["babelify", { "blacklist": ["regenerator"] }]]
   },
   "dependencies": {
+    "autoprefixer": "^5.1.0",
     "postcss-cli": "^2.1.0",
     "browserify": "^11.0.1",
     "loglevel": "^1.2.0",


### PR DESCRIPTION
Running ​node-sass​ on a directory will not output anything so autoprefixer does nothing.
And also autoprefixer’s CLI is now deprecated. This uses the recommended postcss-cli